### PR TITLE
Fix : debconf warning during apt-get install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ FROM mcpayment/ubuntu1404
 #
 # software-properties-common provides apt-add-repository
 
+ARG DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update -y && \
     apt-get install -y software-properties-common && \ 
     apt-add-repository ppa:webupd8team/java && \


### PR DESCRIPTION
https://stackoverflow.com/questions/22466255/is-it-possibe-to-answer-dialog-questions-when-installing-under-docker
